### PR TITLE
feat: always handle exit

### DIFF
--- a/fub/mix.exs
+++ b/fub/mix.exs
@@ -5,7 +5,7 @@ defmodule Fub.MixProject do
     [
       app: :fub,
       version: "0.1.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: [run: ["run --no-halt"]]

--- a/rust_client/.gitignore
+++ b/rust_client/.gitignore
@@ -1,1 +1,3 @@
 target
+target/
+.idea/

--- a/rust_client/src/main.rs
+++ b/rust_client/src/main.rs
@@ -127,7 +127,14 @@ async fn main() -> Result<ExitCode> {
         let _trailing_newline = u_read_buf.pop();
         let cmd = &u_read_buf;
         match cmd[0] {
-            b'z' => (),
+            b'z' => {
+                drop(
+                    fzf.as_mut()
+                        .ok_or_else(|| anyhow!("fzf not open"))?
+                        .stdin
+                        .take(),
+                );
+            }
             b'x' => {
                 std::io::stdout().write_all(&cmd[1..])?;
                 return Ok(ExitCode::SUCCESS);


### PR DESCRIPTION
Flip around the protocol handling state machine:

1) see if there's more data coming in, or if fzf is running and has exited
2) if it's exited, handle that, send the result, close fzf, then go back to processing input
3) if we've got a line, decide what mode we're in, Command or Streaming mode
4) if streaming, send it to fzf
5) otherwise, process the command as normal